### PR TITLE
soong: fix compilation error while building oplus camera

### DIFF
--- a/scripts/check_boot_jars/package_allowed_list.txt
+++ b/scripts/check_boot_jars/package_allowed_list.txt
@@ -300,3 +300,5 @@ vendor\.lineage\.touch.*
 com\.oplus\..*
 com\.oplus\.os
 com\.oplus\.os\..*
+net.oneplus.odm
+oplus.content.res


### PR DESCRIPTION
This commit fixes oneplus camera compilation for the sm8450 variant
Oneplus 10 pro
realme GT 2 pro